### PR TITLE
добавлена поддержка конфигурации порта

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,9 +11,10 @@ nameservers:
 #  - 77.88.8.1:53
 configUpdate: true
 updateInterval: 1m
+#host: localhost
+#port: 10053
 address:
   .local: 127.0.0.1
-port: 10053
 ipsets:
   vpn:
     - graylog.org

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,7 @@ configUpdate: true
 updateInterval: 1m
 address:
   .local: 127.0.0.1
+port: 10053
 ipsets:
   vpn:
     - graylog.org

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	Debug          bool
 	Host           string              `yaml:"host"`
+	Port           uint16              `yaml:"port"`
 	Nameservers    []string            `yaml:"nameservers"`
 	IpSets         map[string][]string `yaml:"ipsets"`
 	Address        map[string]string   `yaml:"address"`

--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ func main() {
 	// start server
 	//port := 5354
 	port := 53
+	if config.Port > 1023 {
+		port = int(config.Port)
+	}
 	server := &dns.Server{Addr: config.Host + ":" + strconv.Itoa(port), Net: "udp"}
 	log.Printf("Starting at %d\n", port)
 	err = server.ListenAndServe()

--- a/wg-dns-ipset.example.conf
+++ b/wg-dns-ipset.example.conf
@@ -5,17 +5,23 @@ ListenPort = 51820
 FwMark = 2
 Table = off
 
+# mkdir -p /etc/iproute2
+# echo "100 wgvpn" >> /etc/iproute2/rt_tables
+
 PostUp = ip route add default dev wgvpn table wgvpn
 PostUp = ip rule add fwmark 0x1 table wgvpn
+PostUp = ipset create vpn hash:ip timeout 0 -exist
 PostUp = iptables -t mangle -A PREROUTING -m set --match-set vpn dst -j MARK --set-mark 0x1
 PostUp = iptables -t mangle -A OUTPUT -m set --match-set vpn dst -j MARK --set-mark 0x1
 PostUp = iptables -t nat -A POSTROUTING -o wgvpn -j MASQUERADE
+#PostUp = sysctl -w  net.ipv4.conf.all.rp_filter=2
+#PostUp = ip route flush cache
 
-PostDown = ip route del default table wgvpn
-PostDown = ip rule delete fwmark 0x1
 PostDown = iptables -t mangle -D OUTPUT 1
 PostDown = iptables -t mangle -D PREROUTING 1
-
+PostDown = ip route del default table wgvpn
+PostDown = ip rule delete fwmark 0x1
+#PostDown = ip route flush cache
 
 # vpn server
 [Peer]


### PR DESCRIPTION
Это необходимо для работы "вторым номером" для AdGuard.
немного обновлены примеры конфигурации

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the server port; defaults to 53 but can run on custom, non-privileged ports (>1023).
  * Enhanced WireGuard example with IPSet-based VPN routing, traffic marking, NAT, and improved PostUp/PostDown cleanup.

* **Documentation**
  * Updated sample configs to illustrate optional host/port settings.
  * Expanded comments with guidance on policy routing, iproute2 tables, rp_filter tuning, and route cache considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->